### PR TITLE
Feat: Decouple getSlugAndLang from the pages dir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,15 +60,19 @@ const getI18nBase = curry((i18n, langKey) =>
 
 /**
  * Get slug (path) and langKey for a given file path.
- * 
+ *
  * Used by gatsby-plugin-i18n and gatsby-plugin-i18n-tags
- * 
+ *
  * @param {*} defaultLangKey default langKey
  * @param {*} fileAbsolutePath local file absolute path
  * @return {{slug: string, langKey: string}} slug and langKey
  */
 const getSlugAndLang = curry((defaultLangKey, fileAbsolutePath) => {
-  const filePath = fileAbsolutePath.split('/pages')[1];
+  const filePath = '/' + fileAbsolutePath
+    .split('/src')[1]
+    .split('/')
+    .slice(2)
+    .join('/');
   const fileName = filePath.split('.');
   const langKey = fileName.length === 3 ? fileName[1] : defaultLangKey;
   const slug = fileName.length === 3

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -113,6 +113,18 @@ describe('langs', () => {
 
       assert.deepEqual(slugAndLangKey, expected);
     });
+
+    it('should accept nodes not in the "pages" dir', () => {
+      const absoluteFilePath = '/home/angeloocana/dev/angeloocana/src/content/blog/linux/arch/extract-files.pt.md';
+      const slugAndLangKey = getSlugAndLang('en', absoluteFilePath);
+      const expected = {
+        slug: '/pt/blog/linux/arch/extract-files/',
+        langKey: 'pt'
+      };
+
+      assert.deepEqual(slugAndLangKey, expected);
+    })
+
   });
 
   describe('isHomePage', () => {


### PR DESCRIPTION
Related : angeloocana/gatsby-plugin-i18n#6

This PR makes `getSlugAndLang` work with nodes not in the `pages` dir.