### PR TITLE
Using native js instead of some ramda helpers.  Added Ramda babel-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,7 @@
     "type": "git",
     "url": "https://github.com/angeloocana/ptz-i18n"
   },
-  "keywords": [
-    "gatsby",
-    "i18n"
-  ],
+  "keywords": ["gatsby", "i18n"],
   "author": "angeloocana.com",
   "license": "MIT",
   "dependencies": {
@@ -30,6 +27,7 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-ramda": "^1.4.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "codecov": "^2.3.0",
@@ -45,15 +43,9 @@
     "ptz-assert": "^1.6.8"
   },
   "babel": {
-    "presets": [
-      "env"
-    ],
-    "plugins": [
-      "transform-object-rest-spread"
-    ],
-    "ignore": [
-      "spec.js,test.js"
-    ]
+    "presets": ["env"],
+    "plugins": ["transform-object-rest-spread", "ramda"],
+    "ignore": ["spec.js,test.js"]
   },
   "readme": "README.md",
   "jest": {

--- a/src/getCurrentLangKey.js
+++ b/src/getCurrentLangKey.js
@@ -6,7 +6,7 @@ import getValidLangKey from './getValidLangKey';
  * @func
  * @param {[String]} langs allowed lang keys ['en', 'fr', 'pt']
  * @param {String} defaultLangKey default browser language key
- * @param {String} url browser url 
+ * @param {String} url browser url
  * @returns {String} current langKey
  */
 const getCurrentLangKey = curry((langs, defaultLangKey, url) => {

--- a/src/getPagesPaths.js
+++ b/src/getPagesPaths.js
@@ -1,4 +1,5 @@
-import { isNil } from 'ramda'
+// import { isNil } from 'ramda';
+import { isNil } from 'ramda';
 import Result from 'folktale/result';
 
 /**
@@ -8,13 +9,13 @@ import Result from 'folktale/result';
  * @return {Result<String[]>} pagesPaths Result
  */
 const getPagesPaths = options => {
-  if(isNil(options)){
+  if (isNil(options)) {
     return Result.Error('Null plugin options');
   }
 
   const { pagesPaths } = options;
 
-  if(isNil(pagesPaths)){
+  if (isNil(pagesPaths)) {
     return Result.Error('Null pluginOptions.pagesPaths');
   }
 
@@ -25,4 +26,3 @@ const getPagesPaths = options => {
 };
 
 export default getPagesPaths;
-

--- a/src/getSlugAndLang.js
+++ b/src/getSlugAndLang.js
@@ -1,4 +1,4 @@
-import { compose, curry, isNil, head, not } from 'ramda';
+import { compose, curry, isNil, head, not, startsWith, endsWith } from 'ramda';
 
 const defaultPagesPaths = ['/src/pages/'];
 
@@ -9,10 +9,10 @@ const getLangKeyDefault = options =>
   (options && options.langKeyDefault) || options;
 
 const addSlashStart = fileName =>
-  fileName.startsWith('/') ? fileName : '/' + fileName;
+  startsWith('/', fileName) ? fileName : '/' + fileName;
 
 const addSlashEnd = fileName =>
-  fileName.endsWith('/') ? fileName : fileName + '/';
+  endsWith('/', fileName) ? fileName : fileName + '/';
 
 const addSlash = compose(addSlashStart, addSlashEnd);
 
@@ -33,9 +33,9 @@ const getSlugAndLang = curry((options, fileAbsolutePath) => {
       return null;
     }
 
+    const langKeyDefault = getLangKeyDefault(options);
     const fileName = filePath.split('.');
-    const langKey =
-      fileName.length === 3 ? fileName[1] : getLangKeyDefault(options);
+    const langKey = fileName.length === 3 ? fileName[1] : langKeyDefault;
     const slug = addSlash(
       (fileName.length === 3 ? langKey : '') +
         addSlash(fileName[0].replace('index', ''))
@@ -43,7 +43,8 @@ const getSlugAndLang = curry((options, fileAbsolutePath) => {
 
     return {
       slug,
-      langKey
+      langKey,
+      redirectTo: slug === '/' ? addSlash(langKeyDefault) : null
     };
   });
 

--- a/src/getSlugAndLang.js
+++ b/src/getSlugAndLang.js
@@ -1,14 +1,18 @@
-import { compose, curry, endsWith, isNil, head, not, startsWith } from 'ramda';
+import { compose, curry, isNil, head, not } from 'ramda';
 
 const defaultPagesPaths = ['/src/pages/'];
 
-const getPagesPaths = options => (options && options.pagesPaths) || defaultPagesPaths;  
+const getPagesPaths = options =>
+  (options && options.pagesPaths) || defaultPagesPaths;
 
-const getLangKeyDefault = options => (options && options.langKeyDefault) || options;
+const getLangKeyDefault = options =>
+  (options && options.langKeyDefault) || options;
 
-const addSlashStart = fileName => startsWith('/', fileName) ? fileName : '/' + fileName;
+const addSlashStart = fileName =>
+  fileName.startsWith('/') ? fileName : '/' + fileName;
 
-const addSlashEnd = fileName => endsWith('/', fileName) ? fileName : fileName + '/';
+const addSlashEnd = fileName =>
+  fileName.endsWith('/') ? fileName : fileName + '/';
 
 const addSlash = compose(addSlashStart, addSlashEnd);
 
@@ -22,27 +26,28 @@ const addSlash = compose(addSlashStart, addSlashEnd);
  * @return {{slug: string, langKey: string}} slug and langKey
  */
 const getSlugAndLang = curry((options, fileAbsolutePath) => {
-  const slugsAndLangs = getPagesPaths(options)
-    .map(pagesPath => {
-      const filePath = `safeStartToSplit-${fileAbsolutePath}`.split(pagesPath)[1];
+  const slugsAndLangs = getPagesPaths(options).map(pagesPath => {
+    const filePath = `safeStartToSplit-${fileAbsolutePath}`.split(pagesPath)[1];
 
-      if(isNil(filePath)){
-        return null;
-      }
+    if (isNil(filePath)) {
+      return null;
+    }
 
-      const fileName = filePath.split('.');
-      const langKey = fileName.length === 3 ? fileName[1] : getLangKeyDefault(options);
-      const slug = addSlash((fileName.length === 3 ? langKey : '') + 
-        addSlash(fileName[0].replace('index', '')));
+    const fileName = filePath.split('.');
+    const langKey =
+      fileName.length === 3 ? fileName[1] : getLangKeyDefault(options);
+    const slug = addSlash(
+      (fileName.length === 3 ? langKey : '') +
+        addSlash(fileName[0].replace('index', ''))
+    );
 
-      return {
-        slug,
-        langKey
-      };
-    });
-  
+    return {
+      slug,
+      langKey
+    };
+  });
+
   return head(slugsAndLangs.filter(compose(not, isNil)));
 });
 
 export default getSlugAndLang;
-

--- a/src/getUserLangKey.js
+++ b/src/getUserLangKey.js
@@ -8,9 +8,7 @@ import { pipe } from 'ramda';
  * @param {String} defaultLangKey default browser language key
  * @return {string} valid langKey
  */
-const getUserLangKey = (langs, defaultLangKey) => pipe(
-  getBrowserLanguage,
-  getValidLangKey(langs, defaultLangKey)
-)();
+const getUserLangKey = (langs, defaultLangKey) =>
+  pipe(getBrowserLanguage, getValidLangKey(langs, defaultLangKey))();
 
 export default getUserLangKey;

--- a/src/getValidLangKey.js
+++ b/src/getValidLangKey.js
@@ -1,4 +1,4 @@
-import { curry, filter, isNil } from 'ramda';
+import { curry, filter, isNil, startsWith } from 'ramda';
 
 /**
  * Get valid langKey in langs or return defaultLangKey
@@ -12,7 +12,7 @@ const getValidLangKey = curry((langs, defaultLangKey, langKey) => {
     return defaultLangKey;
   }
 
-  const currentLangKey = filter(l => langKey.startsWith(l), langs);
+  const currentLangKey = filter(l => startsWith(l, langKey), langs);
   return currentLangKey[0] || defaultLangKey;
 });
 

--- a/src/getValidLangKey.js
+++ b/src/getValidLangKey.js
@@ -1,4 +1,4 @@
-import { curry, filter, startsWith, isNil } from 'ramda';
+import { curry, filter, isNil } from 'ramda';
 
 /**
  * Get valid langKey in langs or return defaultLangKey
@@ -12,7 +12,7 @@ const getValidLangKey = curry((langs, defaultLangKey, langKey) => {
     return defaultLangKey;
   }
 
-  const currentLangKey = filter(l => startsWith(l, langKey), langs);
+  const currentLangKey = filter(l => langKey.startsWith(l), langs);
   return currentLangKey[0] || defaultLangKey;
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { curry } from 'ramda';
+import { curry, startsWith } from 'ramda';
 import getCurrentLangKey from './getCurrentLangKey';
 import getValidLangKey from './getValidLangKey';
 import getBrowserLanguage from './getBrowserLanguage';
@@ -30,7 +30,7 @@ const isHomePage = url => nPaths(url) <= 1;
  * @returns {String} new url
  */
 const getUrlForLang = curry((homeLink, url, langKey) => {
-  return url === '/' || !url.startsWith(homeLink)
+  return url === '/' || !startsWith(homeLink, url)
     ? `/${langKey}/`
     : url.replace(homeLink, `/${langKey}/`);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { curry, startsWith } from 'ramda';
+import { curry } from 'ramda';
 import getCurrentLangKey from './getCurrentLangKey';
 import getValidLangKey from './getValidLangKey';
 import getBrowserLanguage from './getBrowserLanguage';
@@ -13,14 +13,14 @@ import isInPagesPaths from './isInPagesPaths';
  * @param {*} url pathName
  * @returns {Number} number of paths
  */
-const nPaths = (url) => (url.match(/\//g) || []).length - 1;
+const nPaths = url => (url.match(/\//g) || []).length - 1;
 
 /**
  * Checks if the url is /, /en/ or /pt/
  * @param {*} url this.props.location
  * @returns {Boolean} is home or not
  */
-const isHomePage = (url) => nPaths(url) <= 1;
+const isHomePage = url => nPaths(url) <= 1;
 
 /**
  * Get url to the language
@@ -30,7 +30,7 @@ const isHomePage = (url) => nPaths(url) <= 1;
  * @returns {String} new url
  */
 const getUrlForLang = curry((homeLink, url, langKey) => {
-  return url === '/' || !startsWith(homeLink, url)
+  return url === '/' || !url.startsWith(homeLink)
     ? `/${langKey}/`
     : url.replace(homeLink, `/${langKey}/`);
 });
@@ -58,8 +58,9 @@ const getLangs = curry((langs, currentLangKey, getUrlForLang) => {
  * @param {*} langKey langKey
  * @returns {*} i18n[langKey] or i18n[defaultLangKey]
  */
-const getI18nBase = curry((i18n, langKey) =>
-  i18n[langKey] || Object.values(i18n)[0]);
+const getI18nBase = curry(
+  (i18n, langKey) => i18n[langKey] || Object.values(i18n)[0]
+);
 
 export {
   isHomePage,
@@ -76,4 +77,3 @@ export {
   nPaths,
   redirectToHome
 };
-

--- a/src/isInPagesPaths.js
+++ b/src/isInPagesPaths.js
@@ -15,4 +15,3 @@ const isInPagesPaths = (options, path) => {
 };
 
 export default isInPagesPaths;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,12 @@ babel-plugin-jest-hoist@^21.0.2:
   version "21.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.0.2.tgz#cfdce5bca40d772a056cb8528ad159c7bb4bb03d"
 
+babel-plugin-ramda@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ramda/-/babel-plugin-ramda-1.4.3.tgz#265b54a92f29f5ed56180b95c499d1ae2a8a25a7"
+  dependencies:
+    ramda "0.x"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -2832,6 +2838,14 @@ punycode@^1.4.1:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+rambda@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/rambda/-/rambda-1.0.6.tgz#2ea321c578d64ce5249ad905dc03b70df8189d20"
+
+ramda@0.x:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
 
 ramda@^0.24.1:
   version "0.24.1"


### PR DESCRIPTION
Ramda is fantastic however it does add a lot of needles bloat to my project.  Adding [babel-plugin-ramda](https://github.com/megawac/babel-plugin-ramda) helps reduce some of that bloat. I've added that plugin to your build config and removed some basic helpers (`startsWIth` & `endsWith`) to reduce some bloat

Ideally it would be great to implement these helpers as 100% vanilla JS 